### PR TITLE
Unique email constraint

### DIFF
--- a/src/database/migrations/20221019111852_email_unique_constraint.ts
+++ b/src/database/migrations/20221019111852_email_unique_constraint.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user', (table) => {
+    table.unique(['email']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user', (table) => {
+    table.dropUnique(['email']);
+  });
+}


### PR DESCRIPTION
Tämä migraatiohan ei tietenkään mene läpi, mikäli käyttämässäsi tietokannassa on duplikaatteja sähköposteja. Niitä on saattanut syntyä esim siksi ettei updateUser tarkastanut tätä tai jokin muu "race condition". Poista ne käsin.