### PR TITLE
Fix primary key issue

### DIFF
--- a/src/database/migrations/20240119142857_fix_fill_event_gas_fill_primary_key.ts
+++ b/src/database/migrations/20240119142857_fix_fill_event_gas_fill_primary_key.ts
@@ -1,0 +1,12 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`ALTER TABLE fill_event_gas_fill DROP PRIMARY KEY;`);
+  await knex.raw(
+    'ALTER TABLE fill_event_gas_fill ADD CONSTRAINT PRIMARY KEY (fill_event_id, storage_cylinder_id)'
+  );
+}
+
+export async function down(): Promise<void> {
+  // noop
+}

--- a/src/database/migrations/20240119142857_fix_fill_event_gas_fill_primary_key.ts
+++ b/src/database/migrations/20240119142857_fix_fill_event_gas_fill_primary_key.ts
@@ -1,10 +1,12 @@
 import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`SET foreign_key_checks = 0;`);
   await knex.raw(`ALTER TABLE fill_event_gas_fill DROP PRIMARY KEY;`);
   await knex.raw(
-    'ALTER TABLE fill_event_gas_fill ADD CONSTRAINT PRIMARY KEY (fill_event_id, storage_cylinder_id)'
+    'ALTER TABLE fill_event_gas_fill ADD COLUMN id UUID DEFAULT UUID() NOT NULL PRIMARY KEY;'
   );
+  await knex.raw(`SET foreign_key_checks = 1;`);
 }
 
 export async function down(): Promise<void> {


### PR DESCRIPTION
Fill event gas fill had invalid primary key, which denied user from creating a fill event with two different storage cylinders that held the same gas. Use case is that you fill e.g. oxygen from storage cylinder 1 and it dries out and then you fill little bit more from storage cylinder 2.